### PR TITLE
chore:refactor date parser methods

### DIFF
--- a/src/main/java/org/isf/orthanc/model/BaseResponse.java
+++ b/src/main/java/org/isf/orthanc/model/BaseResponse.java
@@ -92,7 +92,7 @@ public class BaseResponse {
 	 *
 	 * @return {@link LocalDateTime} instance
 	 */
-	public LocalDateTime getLastUpdateInstance() {
+	public LocalDateTime lastUpdateToLocalDateTime() {
 		if (lastUpdate == null || lastUpdate.isEmpty()) {
 			return  null;
 		}

--- a/src/main/java/org/isf/orthanc/model/Instance.java
+++ b/src/main/java/org/isf/orthanc/model/Instance.java
@@ -113,7 +113,7 @@ public class Instance {
 	 * Parse instance creation date into LocalDate
 	 * @return {@link LocalDate} instance
 	 */
-	public LocalDate getCreationDateInstance() {
+	public LocalDate creationDateToLocalDate() {
 		if (creationDate == null || creationDate.isEmpty()) {
 			return  null;
 		}
@@ -125,7 +125,7 @@ public class Instance {
 	 * Parse instance creation time into LocalTime
 	 * @return {@link LocalTime} instance
 	 */
-	public LocalTime getCreationTimeInstance() {
+	public LocalTime creationTimeToLocalTime() {
 		if (creationTime == null || creationTime.isEmpty()) {
 			return  null;
 		}

--- a/src/main/java/org/isf/orthanc/model/Patient.java
+++ b/src/main/java/org/isf/orthanc/model/Patient.java
@@ -80,7 +80,7 @@ public class Patient {
 	 * Parse birthdate into LocalDate
 	 * @return {@link LocalDate} instance
 	 */
-	public LocalDate getBirthDateInstance() {
+	public LocalDate birthDateToLocalDate() {
 		if (birthDate == null || birthDate.isEmpty()) {
 			return  null;
 		}

--- a/src/main/java/org/isf/orthanc/model/Study.java
+++ b/src/main/java/org/isf/orthanc/model/Study.java
@@ -126,7 +126,7 @@ public class Study {
 	 * Parse study date into LocalDate
 	 * @return {@link LocalDate} instance
 	 */
-	public LocalDate getDateInstance() {
+	public LocalDate dateToLocalDate() {
 		if (date == null || date.isEmpty()) {
 			return  null;
 		}
@@ -138,7 +138,7 @@ public class Study {
 	 * Parse study time into LocalTime
 	 * @return {@link LocalTime} instance
 	 */
-	public LocalTime getTimeInstance() {
+	public LocalTime timeToLocalTime() {
 		if (time == null || time.isEmpty()) {
 			return  null;
 		}

--- a/src/test/java/org/isf/orthanc/service/OrthancAPIClientServiceTest.java
+++ b/src/test/java/org/isf/orthanc/service/OrthancAPIClientServiceTest.java
@@ -99,7 +99,7 @@ public class OrthancAPIClientServiceTest extends OHCoreTestCase {
 
 		assertThat(studies).isNotNull();
 		assertThat(studies.getStudy()).isNotNull();
-		assertThat(studies.getLastUpdateInstance()).isInstanceOf(LocalDateTime.class);
+		assertThat(studies.lastUpdateToLocalDateTime()).isInstanceOf(LocalDateTime.class);
 	}
 
 	@Test


### PR DESCRIPTION
I refactor methods in orthanc data model that parse string dates to Java dates. This methods were considered as getters and were creating extra props in DTOs.